### PR TITLE
fix make MTEST=serial=500000 casasagi:mtei:flash

### DIFF
--- a/keyboards/casasagi/keymaps/mtei/local_features.mk
+++ b/keyboards/casasagi/keymaps/mtei/local_features.mk
@@ -28,7 +28,7 @@ ifneq ($(strip $(MTEST)),)
         MDELAY = $(patsubst mdelay=%,%,$1)
     endif
     ifneq ($(filter serial=%,$1),)
-        SERIAL = $(patsubst serial=%,%,$1)
+        USART_SPEED = $(patsubst serial=%,%,$1)
     endif
     ifeq ($(strip $1),mdelay0)
         MDELAY = 0
@@ -53,8 +53,8 @@ ifneq ($(strip $(MDELAY)),)
     OPT_DEFS += -DMATRIX_IO_DELAY=$(strip $(MDELAY))
 endif
 
-ifneq ($(strip $(SERIAL)),)
-    OPT_DEFS += -DSERIAL_USART_SPEED=$(strip $(SERIAL))
+ifneq ($(strip $(USART_SPEED)),)
+    OPT_DEFS += -DSERIAL_USART_SPEED=$(strip $(USART_SPEED))
 endif
 
 ifneq ($(strip $(MATRIX_COMMON_DELAY)),yes)

--- a/keyboards/casasagi/keymaps/mtei/local_features.mk
+++ b/keyboards/casasagi/keymaps/mtei/local_features.mk
@@ -12,8 +12,8 @@
 
 ifneq ($(strip $(MTEST)),)
   define KEYBOARD_OPTION_PARSE
-    # parse 'consle', 'scan', 'no-scan', 'mdelay=?', 'mdelay0',
-    #       'common_delay', 'serial=?'
+    # parse 'consle', 'scan', 'no-scan', 'mdelay=?', 'mdelay0', 'no-led', 'led',
+    #       'common_delay', 'serial=?', 'no-mouse', 'no-extrakey'
     $(if $(SHOW_PARSE),$(info parse .$1.))  #for debug  'make SHOW_PARSE=y ...'
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
@@ -21,8 +21,20 @@ ifneq ($(strip $(MTEST)),)
     ifeq ($(strip $1),scan)
         DEBUG_MATRIX_SCAN_RATE_ENABLE = yes
     endif
-    ifeq ($(strip $1),no-scan)
+    ifneq ($(filter no-scan no_scan,$(strip $1)),)
         DEBUG_MATRIX_SCAN_RATE_ENABLE = no
+    endif
+    ifeq ($(strip $1),led)
+        RGBLIGHT_ENABLE = yes
+    endif
+    ifneq ($(filter no-led no_led,$(strip $1)),)
+        RGBLIGHT_ENABLE = no
+    endif
+    ifneq ($(filter no-mouse no_mouse,$(strip $1)),)
+        MOUSEKEY_ENABLE = no
+    endif
+    ifneq ($(filter no-extrakey no_extrakey,$(strip $1)),)
+        EXTRAKEY_ENABLE = no
     endif
     ifneq ($(filter mdelay=%,$1),)
         MDELAY = $(patsubst mdelay=%,%,$1)
@@ -36,11 +48,11 @@ ifneq ($(strip $(MTEST)),)
     ifeq ($(strip $1),common_delay)
         MATRIX_COMMON_DELAY = yes
     endif
-    ifeq ($(strip $1),no_sync_timer)
-	NO_SYNC_TIMER = yes
+    ifneq ($(filter no-sync-timer no_sync_timer,$(strip $1)),)
+        NO_SYNC_TIMER = yes
     endif
-    ifeq ($(strip $1),sync_timer)
-	NO_SYNC_TIMER = no
+    ifneq ($(filter sync-timer sync_timer,$(strip $1)),)
+        NO_SYNC_TIMER = no
     endif
   endef # end of KEYMAP_OPTION_PARSE
 
@@ -64,3 +76,17 @@ endif
 ifeq ($(strip $(NO_SYNC_TIMER)),yes)
     OPT_DEFS += -DDISABLE_SYNC_TIMER
 endif
+
+$(info -  RGBLIGHT_ENABLE     = $(RGBLIGHT_ENABLE))
+$(info -  MDELAY              = $(MDELAY))
+$(info -  USART_SPEED         = $(USART_SPEED))
+$(info -  MATRIX_COMMON_DELAY = $(MATRIX_COMMON_DELAY))
+$(info -  NO_SYNC_TIMER       = $(NO_SYNC_TIMER))
+$(info -  OLED_DRIVER_ENABLE  = $(OLED_DRIVER_ENABLE))
+$(info -  CONSOLE_ENABLE      = $(CONSOLE_ENABLE))
+$(info -  SPLIT_KEYBOARD      = $(SPLIT_KEYBOARD))
+$(info -  LTO_ENABLE          = $(LTO_ENABLE))
+$(info -  DEBUG_MATRIX_SCAN_RATE_ENABLE = $(DEBUG_MATRIX_SCAN_RATE_ENABLE))
+$(info -  MOUSEKEY_ENABLE     = $(MOUSEKEY_ENABLE))
+$(info -  EXTRAKEY_ENABLE     = $(EXTRAKEY_ENABLE))
+$(info -  OPT_DEFS            = $(OPT_DEFS))

--- a/keyboards/casasagi/keymaps/mtei/local_features.mk
+++ b/keyboards/casasagi/keymaps/mtei/local_features.mk
@@ -13,7 +13,7 @@
 ifneq ($(strip $(MTEST)),)
   define KEYBOARD_OPTION_PARSE
     # parse 'consle', 'scan', 'no-scan', 'mdelay=?', 'mdelay0', 'no-led', 'led',
-    #       'common_delay', 'serial=?', 'no-mouse', 'no-extrakey'
+    #       'common_delay', 'serial=?', 'no-mouse', 'no-extrakey', 'adelay'
     $(if $(SHOW_PARSE),$(info parse .$1.))  #for debug  'make SHOW_PARSE=y ...'
     ifeq ($(strip $1),console)
         CONSOLE_ENABLE = yes
@@ -48,6 +48,9 @@ ifneq ($(strip $(MTEST)),)
     ifeq ($(strip $1),common_delay)
         MATRIX_COMMON_DELAY = yes
     endif
+    ifeq ($(strip $1),adelay)
+        ACCURATE_DELAY = yes
+    endif
     ifneq ($(filter no-sync-timer no_sync_timer,$(strip $1)),)
         NO_SYNC_TIMER = yes
     endif
@@ -63,6 +66,10 @@ endif
 
 ifneq ($(strip $(MDELAY)),)
     OPT_DEFS += -DMATRIX_IO_DELAY=$(strip $(MDELAY))
+endif
+
+ifeq ($(strip $(ACCURATE_DELAY)), yes)
+    OPT_DEFS += -DACCURATE_DELAY
 endif
 
 ifneq ($(strip $(USART_SPEED)),)

--- a/keyboards/casasagi/keymaps/mtei/own_matrix_delay.c
+++ b/keyboards/casasagi/keymaps/mtei/own_matrix_delay.c
@@ -1,8 +1,23 @@
+#include <stdint.h>
 #include "quantum.h"
 #include "wait.h"
 
 #ifndef MATRIX_IO_DELAY
 #    define MATRIX_IO_DELAY 30
+#endif
+
+#ifdef ACCURATE_DELAY
+static void half_micro_delay(void) {
+    wait_cpuclock(STM32_SYSCLK / 1000000L / 2);
+}
+
+static void wait_accurate_us(unsigned int n) {
+    for (n *= 2; n > 0; n--) {
+        half_micro_delay();
+    }
+}
+#undef wait_us
+#define wait_us(n) wait_accurate_us(n)
 #endif
 
 /* In tmk_core/common/wait.h, the implementation for PROTOCOL_CHIBIOS


### PR DESCRIPTION
## Description

コマンドラインから、
```shell
make MTEST=serial=500000 casasagi:mtei:flash
```
で、シリアルスピードを指定できるように casasagi/keymaps/mtei/local_features.mk の中で書いていたのですが、中で使っている 'SERIAL' という名前の変数が tmk_core/chibios.mk とぶつかっていて、flash に失敗していました。

tmk_core/chibios.mk use 'SERIAL'
```makefile
DFU_ARGS ?=
ifneq ("$(SERIAL)","")
        DFU_ARGS += -S $(SERIAL)
endif
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

